### PR TITLE
Add search endpoint request

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ DatastoreApi::Requests::UpdateApplication.new(
 DatastoreApi::Requests::DeleteApplication.new(
   application_id: 'uuid'
 ).call
+
+# Search applications, optionally paginated
+DatastoreApi::Requests::SearchApplications.new(
+  search_text: 'John', 
+  pagination: { per_page: 5, page: 2 }
+).call
 ```
 
 ## Development

--- a/lib/datastore_api.rb
+++ b/lib/datastore_api.rb
@@ -16,6 +16,7 @@ require_relative 'datastore_api/traits/paginated_response'
 require_relative 'datastore_api/requests/create_application'
 require_relative 'datastore_api/requests/get_application'
 require_relative 'datastore_api/requests/list_applications'
+require_relative 'datastore_api/requests/search_applications'
 require_relative 'datastore_api/requests/update_application'
 require_relative 'datastore_api/requests/delete_application'
 

--- a/lib/datastore_api/requests/search_applications.rb
+++ b/lib/datastore_api/requests/search_applications.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Requests
+    class SearchApplications
+      include Traits::ApiRequest
+      include Traits::PaginatedResponse
+
+      attr_reader :criteria, :pagination
+
+      # Instantiate a new search
+      #
+      # @option pagination [Hash] Pagination options. Optional
+      # @option criteria [Hash] Search criteria
+      #
+      # @raise [ArgumentError] if no +criteria+ is provided
+      # @return [DatastoreApi::Requests::GetApplication] instance
+      #
+      def initialize(pagination: {}, **criteria)
+        raise ArgumentError, 'search criteria is required' unless criteria.any?
+
+        @pagination = pagination
+        @criteria = criteria
+      end
+
+      # Get a list of applications by criteria, optionally paginated
+      #
+      # @raise [DatastoreApi::Errors::ApiError] refer to lib/datastore_api/errors.rb
+      # @return [Decorators::PaginatedCollection] paginated collection
+      #
+      def call
+        paginated_response(
+          http_client.post(endpoint, payload)
+        )
+      end
+
+      def endpoint
+        '/searches'
+      end
+
+      private
+
+      def payload
+        { search: criteria, pagination: pagination }
+      end
+    end
+  end
+end

--- a/spec/datastore_api/requests/search_applications_spec.rb
+++ b/spec/datastore_api/requests/search_applications_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Requests::SearchApplications do
+  subject { described_class.new(**args) }
+
+  let(:http_client) { instance_double(DatastoreApi::HttpClient, post: response) }
+
+  let(:args) do
+    {
+      search_text: 'John',
+      pagination: { per_page: 5 }
+    }
+  end
+
+  let(:response) { { 'pagination' => { limit: 10 }, 'records' => [{}, {}] } }
+
+  describe '.new' do
+    let(:args) { {} }
+
+    it 'raises an error if there is no criteria' do
+      expect {
+        subject.call
+      }.to raise_error(ArgumentError, 'search criteria is required')
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(subject).to receive(:http_client).and_return(http_client)
+    end
+
+    it_behaves_like 'an API request'
+
+    it 'wraps the response in a PaginatedCollection' do
+      expect(subject.call).to be_a(DatastoreApi::Decorators::PaginatedCollection)
+    end
+
+    it 'returns applications' do
+      expect(subject.call.size).to eq(2)
+    end
+
+    it 'returns the pagination metadata' do
+      expect(subject.call.pagination).to eq({ limit: 10 })
+    end
+
+    context 'endpoint' do
+      it 'posts to the correct endpoint' do
+        expect(http_client).to receive(:post).with('/searches', any_args)
+        subject.call
+      end
+    end
+
+    context 'payload' do
+      it 'posts the correct payload' do
+        expect(http_client).to receive(:post).with(
+          any_args, { search: { search_text: 'John' }, pagination: { per_page: 5 } }
+        )
+        subject.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will search by any criteria that the datastore allows. Optionally, the `pagination` hash object can be passed to configure the pagination. If not provided, default pagination values will be used in the response.