### PR TITLE
Make the `UpdateApplication` request more flexible

### DIFF
--- a/lib/datastore_api/requests/update_application.rb
+++ b/lib/datastore_api/requests/update_application.rb
@@ -5,24 +5,26 @@ module DatastoreApi
     class UpdateApplication
       include Traits::ApiRequest
 
-      attr_reader :application_id, :payload
+      attr_reader :application_id, :payload, :member
 
       # Instantiate a new application to be updated
       #
       # @param application_id [String] The application UUID to retrieve
       # @param payload [Hash] All properties to be sent in the payload
+      # @param member [Symbol] Member route. Optional
       #
       # @raise [ArgumentError] if +application_id+ is missing or +nil+
       # @raise [ArgumentError] if +payload+ is missing or +nil+
       #
       # @return [DatastoreApi::Requests::UpdateApplication] instance
       #
-      def initialize(application_id:, payload:)
+      def initialize(application_id:, payload:, member: nil)
         raise ArgumentError, '`application_id` cannot be nil' unless application_id
         raise ArgumentError, '`payload` cannot be nil' unless payload
 
         @application_id = application_id
         @payload = payload
+        @member = member
       end
 
       # Update an existing application
@@ -38,8 +40,14 @@ module DatastoreApi
 
       def endpoint
         format(
-          '/applications/%<application_id>s', application_id: application_id
+          '/applications/%<resource_path>s', resource_path: resource_path
         )
+      end
+
+      private
+
+      def resource_path
+        [application_id, member].compact.join('/')
       end
     end
   end

--- a/spec/datastore_api/requests/update_application_spec.rb
+++ b/spec/datastore_api/requests/update_application_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe DatastoreApi::Requests::UpdateApplication do
         expect(http_client).to receive(:put).with('/applications/xyz-123', any_args)
         subject.call
       end
+
+      context 'when a `member` is provided' do
+        let(:args) do
+          { application_id: 'xyz-123', payload: {}, member: :revoke }
+        end
+
+        it 'puts to the correct endpoint' do
+          expect(http_client).to receive(:put).with('/applications/xyz-123/revoke', any_args)
+          subject.call
+        end
+      end
     end
 
     context 'payload' do


### PR DESCRIPTION
Support RESTful endpoints with an optional member.

By default, no member is used, so the PUT request endpoint will result in `/applications/{uuid}`

If a `member` argument is provided, then the endpoint will be: `/applications/{uuid}/{member}` so for instance, this will support our current need for the return applications endpoint: `PUT to /applications/{uuid}/return`.

```
DatastoreApi::Requests::UpdateApplication.new(
  application_id: 'uuid',
  payload: {...},
  member: :return
).call
```