### PR TITLE
Add `moj-simple-jwt-auth` gem dependency

### DIFF
--- a/laa-criminal-applications-datastore-api-client.gemspec
+++ b/laa-criminal-applications-datastore-api-client.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_runtime_dependency 'faraday', '~> 2.6'
+  spec.add_runtime_dependency 'moj-simple-jwt-auth', '0.0.1'
 end


### PR DESCRIPTION
This makes sense as both Apply and Review use this API client, so no longer is needed to add this gem separately in their Gemfile.