### PR TITLE
Add health check endpoint request

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ DatastoreApi::Requests::SearchApplications.new(
   search_text: 'John', 
   pagination: { per_page: 5, page: 2 }
 ).call
+
+# Health check endpoint
+DatastoreApi::Requests::Healthcheck.call
 ```
 
 ## Development

--- a/laa-criminal-applications-datastore-api-client.gemspec
+++ b/laa-criminal-applications-datastore-api-client.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.0'
 
   spec.add_runtime_dependency 'faraday', '~> 2.6'
-  spec.add_runtime_dependency 'moj-simple-jwt-auth', '0.0.1'
+  spec.add_runtime_dependency 'moj-simple-jwt-auth', '~> 0.1.0'
 end

--- a/lib/datastore_api.rb
+++ b/lib/datastore_api.rb
@@ -13,6 +13,7 @@ require_relative 'datastore_api/decorators/paginated_collection'
 require_relative 'datastore_api/traits/api_request'
 require_relative 'datastore_api/traits/paginated_response'
 
+require_relative 'datastore_api/requests/healthcheck'
 require_relative 'datastore_api/requests/create_application'
 require_relative 'datastore_api/requests/get_application'
 require_relative 'datastore_api/requests/list_applications'
@@ -21,6 +22,7 @@ require_relative 'datastore_api/requests/update_application'
 require_relative 'datastore_api/requests/delete_application'
 
 require_relative 'datastore_api/responses/application_result'
+require_relative 'datastore_api/responses/healthcheck_result'
 
 module DatastoreApi
 end

--- a/lib/datastore_api/requests/healthcheck.rb
+++ b/lib/datastore_api/requests/healthcheck.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Requests
+    class Healthcheck
+      include Traits::ApiRequest
+
+      def self.call
+        new.call
+      end
+
+      # Get a health check result
+      #
+      # @raise [DatastoreApi::Errors::ApiError] refer to lib/datastore_api/errors.rb
+      # @return [Responses::HealthcheckResult] result response
+      #
+      def call
+        Responses::HealthcheckResult.new(
+          http_client.get(endpoint)
+        )
+      end
+
+      def endpoint
+        '/health'
+      end
+    end
+  end
+end

--- a/lib/datastore_api/responses/healthcheck_result.rb
+++ b/lib/datastore_api/responses/healthcheck_result.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Responses
+    class HealthcheckResult < SimpleDelegator
+      FIELDS = %w[
+        status
+        error
+      ].freeze
+
+      attr_reader(*FIELDS)
+
+      # Instantiate a health check result
+      #
+      # @param response [Hash] The API response for the operation
+      # @return [DatastoreApi::Responses::HealthcheckResult] instance
+      #
+      def initialize(response)
+        FIELDS.each do |field|
+          instance_variable_set(:"@#{field}", response[field])
+        end
+
+        super
+      end
+
+      def success?
+        error.nil?
+      end
+
+      def error?
+        !success?
+      end
+    end
+  end
+end

--- a/lib/datastore_api/version.rb
+++ b/lib/datastore_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatastoreApi
-  VERSION = '0.0.1'
+  VERSION = '0.1.0'
 end

--- a/spec/datastore_api/requests/healthcheck_spec.rb
+++ b/spec/datastore_api/requests/healthcheck_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Requests::Healthcheck do
+  subject { described_class.new }
+
+  let(:http_client) { instance_double(DatastoreApi::HttpClient, get: {}) }
+
+  describe '.call' do
+    it 'delegates to the instance' do
+      expect(described_class).to receive(:new).and_return(double.as_null_object)
+      described_class.call
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(subject).to receive(:http_client).and_return(http_client)
+    end
+
+    it_behaves_like 'an API request'
+
+    it 'wraps the response in an HealthcheckResult' do
+      expect(subject.call).to be_a(DatastoreApi::Responses::HealthcheckResult)
+    end
+
+    context 'endpoint' do
+      it 'gets the correct endpoint' do
+        expect(http_client).to receive(:get).with('/health')
+        subject.call
+      end
+    end
+  end
+end

--- a/spec/datastore_api/responses/healthcheck_result_spec.rb
+++ b/spec/datastore_api/responses/healthcheck_result_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Responses::HealthcheckResult do
+  subject { described_class.new(response) }
+
+  describe 'FIELDS' do
+    it {
+      expect(
+        described_class::FIELDS
+      ).to eq(%w[
+        status
+        error
+      ])
+    }
+  end
+
+  describe '.new' do
+    context 'delegation' do
+      let(:response) do
+        { 'status' => 'ok', 'error' => nil, 'foobar' => 'test' }
+      end
+
+      it 'assigns basic attributes, delegates the rest' do
+        expect(subject.status).to eq('ok')
+        expect(subject.error).to be_nil
+
+        expect(subject['foobar']).to eq('test')
+      end
+    end
+  end
+
+  describe '#error?' do
+    let(:response) { { 'error' => error } }
+
+    context 'when there is no error' do
+      let(:error) { nil }
+
+      it { expect(subject.error?).to be(false) }
+    end
+
+    context 'when there is an error' do
+      let(:error) { 'boom!' }
+
+      it { expect(subject.error?).to be(true) }
+    end
+  end
+
+  describe '#success?' do
+    let(:response) { { 'error' => error } }
+
+    context 'when there is no error' do
+      let(:error) { nil }
+
+      it { expect(subject.success?).to be(true) }
+    end
+
+    context 'when there is an error' do
+      let(:error) { 'boom!' }
+
+      it { expect(subject.success?).to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
Add a health check request operation.

Also bumps the version of the gem, and the `moj-simple-jwt-auth` dependency.

It works together with this other PR
https://github.com/ministryofjustice/laa-criminal-applications-datastore/pull/85

```ruby
x = DatastoreApi::Requests::Healthcheck.call
=> {"status"=>"ok", "error"=>nil}
irb(main)> x.error?
=> false
irb(main)> x.success?
=> true
```