### PR TITLE
Refreshen code and update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0.4', '3.1.2']
+        ruby: ['3.2.1', '3.2.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: enable
   Exclude:
@@ -22,3 +22,8 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 15
+
+# https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+  EnforcedShorthandSyntax: consistent

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,80 @@
+PATH
+  remote: .
+  specs:
+    laa-criminal-applications-datastore-api-client (1.0.0)
+      faraday (~> 2.7)
+      moj-simple-jwt-auth (~> 0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    json (2.6.3)
+    jwt (2.7.1)
+    language_server-protocol (3.17.0.3)
+    moj-simple-jwt-auth (0.1.0)
+      json
+      jwt
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.8.1)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    rubocop (1.54.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.3)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  laa-criminal-applications-datastore-api-client!
+  rake
+  rspec
+  rubocop
+  simplecov
+
+BUNDLED WITH
+   2.3.17

--- a/laa-criminal-applications-datastore-api-client.gemspec
+++ b/laa-criminal-applications-datastore-api-client.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '~> 3.2.1'
 
-  spec.add_runtime_dependency 'faraday', '~> 2.6'
+  spec.add_runtime_dependency 'faraday', '~> 2.7'
   spec.add_runtime_dependency 'moj-simple-jwt-auth', '~> 0.1.0'
 end

--- a/lib/datastore_api/requests/delete_application.rb
+++ b/lib/datastore_api/requests/delete_application.rb
@@ -33,7 +33,7 @@ module DatastoreApi
 
       def endpoint
         format(
-          '/applications/%<application_id>s', application_id: application_id
+          '/applications/%<application_id>s', application_id:
         )
       end
     end

--- a/lib/datastore_api/requests/get_application.rb
+++ b/lib/datastore_api/requests/get_application.rb
@@ -33,7 +33,7 @@ module DatastoreApi
 
       def endpoint
         format(
-          '/applications/%<application_id>s', application_id: application_id
+          '/applications/%<application_id>s', application_id:
         )
       end
     end

--- a/lib/datastore_api/requests/list_applications.rb
+++ b/lib/datastore_api/requests/list_applications.rb
@@ -41,7 +41,7 @@ module DatastoreApi
       private
 
       def query
-        { status: status }.merge(query_params)
+        { status: }.merge(query_params)
       end
     end
   end

--- a/lib/datastore_api/requests/update_application.rb
+++ b/lib/datastore_api/requests/update_application.rb
@@ -40,7 +40,7 @@ module DatastoreApi
 
       def endpoint
         format(
-          '/applications/%<resource_path>s', resource_path: resource_path
+          '/applications/%<resource_path>s', resource_path:
         )
       end
 

--- a/lib/datastore_api/version.rb
+++ b/lib/datastore_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatastoreApi
-  VERSION = '0.1.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
No functional changes, just enforcing a higher ruby version and updating some outdated gems, like rubocop, faraday, etc.

Fixed a few rubocop offences with hashes shorthand style.

Bumped to v1.0.0 mainly because everything needed for MVP is covered in this version of the gem, and going forward if new endpoints are created, we will add them and start bumping the gem version with it.