### PR TITLE
CRIMAP-462 Rails engine exposing health endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'rails'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,162 @@
 PATH
   remote: .
   specs:
-    laa-criminal-applications-datastore-api-client (1.0.0)
+    laa-criminal-applications-datastore-api-client (1.1.0)
       faraday (~> 2.7)
       moj-simple-jwt-auth (~> 0.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.0.6)
+      actionpack (= 7.0.6)
+      activesupport (= 7.0.6)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.6)
+      actionpack (= 7.0.6)
+      activejob (= 7.0.6)
+      activerecord (= 7.0.6)
+      activestorage (= 7.0.6)
+      activesupport (= 7.0.6)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.6)
+      actionpack (= 7.0.6)
+      actionview (= 7.0.6)
+      activejob (= 7.0.6)
+      activesupport (= 7.0.6)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.6)
+      actionview (= 7.0.6)
+      activesupport (= 7.0.6)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.6)
+      actionpack (= 7.0.6)
+      activerecord (= 7.0.6)
+      activestorage (= 7.0.6)
+      activesupport (= 7.0.6)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.6)
+      activesupport (= 7.0.6)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.6)
+      activesupport (= 7.0.6)
+      globalid (>= 0.3.6)
+    activemodel (7.0.6)
+      activesupport (= 7.0.6)
+    activerecord (7.0.6)
+      activemodel (= 7.0.6)
+      activesupport (= 7.0.6)
+    activestorage (7.0.6)
+      actionpack (= 7.0.6)
+      activejob (= 7.0.6)
+      activerecord (= 7.0.6)
+      activesupport (= 7.0.6)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
+    builder (3.2.4)
+    concurrent-ruby (1.2.2)
+    crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
+    erubi (1.12.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
     json (2.6.3)
     jwt (2.7.1)
     language_server-protocol (3.17.0.3)
+    loofah (2.21.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
+    minitest (5.18.1)
     moj-simple-jwt-auth (0.1.0)
       json
       jwt
+    net-imap (0.3.6)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.9)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
     racc (1.7.1)
+    rack (2.2.7)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rails (7.0.6)
+      actioncable (= 7.0.6)
+      actionmailbox (= 7.0.6)
+      actionmailer (= 7.0.6)
+      actionpack (= 7.0.6)
+      actiontext (= 7.0.6)
+      actionview (= 7.0.6)
+      activejob (= 7.0.6)
+      activemodel (= 7.0.6)
+      activerecord (= 7.0.6)
+      activestorage (= 7.0.6)
+      activesupport (= 7.0.6)
+      bundler (>= 1.15.0)
+      railties (= 7.0.6)
+    rails-dom-testing (2.1.1)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.0.6)
+      actionpack (= 7.0.6)
+      activesupport (= 7.0.6)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.1)
@@ -43,7 +174,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
-    rubocop (1.54.1)
+    rubocop (1.54.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -64,13 +195,22 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    thor (1.2.2)
+    timeout (0.4.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   laa-criminal-applications-datastore-api-client!
+  rails
   rake
   rspec
   rubocop

--- a/engines/app/controllers/datastore_api/health_engine/application_controller.rb
+++ b/engines/app/controllers/datastore_api/health_engine/application_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module HealthEngine
+    class ApplicationController < ActionController::Base
+    end
+  end
+end

--- a/engines/app/controllers/datastore_api/health_engine/healthcheck_controller.rb
+++ b/engines/app/controllers/datastore_api/health_engine/healthcheck_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module HealthEngine
+    class HealthcheckController < ApplicationController
+      def show
+        healthcheck = DatastoreApi::HealthEngine::GetRequest.call(:health)
+        render json: healthcheck.response, status: healthcheck.status
+      end
+
+      def ping
+        ping = DatastoreApi::HealthEngine::GetRequest.call(:ping)
+        render json: ping.response, status: ping.status
+      end
+    end
+  end
+end

--- a/engines/app/services/datastore_api/health_engine/get_request.rb
+++ b/engines/app/services/datastore_api/health_engine/get_request.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module HealthEngine
+    class GetRequest
+      attr_reader :action, :response, :status
+
+      def initialize(action)
+        @action = action
+      end
+      private_class_method :new
+
+      def self.call(action)
+        new(action).call
+      end
+
+      def call
+        do_request
+        self
+      end
+
+      private
+
+      def do_request
+        res = Faraday.get(endpoint)
+
+        @status = res.success? ? :ok : :service_unavailable
+        @response = JSON.parse(res.body)
+      rescue StandardError => e
+        @status = :service_unavailable
+        @response = { error: e.message }
+      end
+
+      def endpoint
+        [DatastoreApi.configuration.api_root, action].join('/')
+      end
+    end
+  end
+end

--- a/engines/config/routes.rb
+++ b/engines/config/routes.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+DatastoreApi::HealthEngine::Engine.routes.draw do
+  get :health, to: 'healthcheck#show'
+  get :ping,   to: 'healthcheck#ping'
+end

--- a/engines/health_engine.rb
+++ b/engines/health_engine.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module HealthEngine
+    class Engine < ::Rails::Engine
+      isolate_namespace DatastoreApi::HealthEngine
+      config.root = "#{root}/engines"
+    end
+  end
+end

--- a/laa-criminal-applications-datastore-api-client.gemspec
+++ b/laa-criminal-applications-datastore-api-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  end + Dir['engines/**/*.rb']
 
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/datastore_api.rb
+++ b/lib/datastore_api.rb
@@ -24,5 +24,7 @@ require_relative 'datastore_api/requests/delete_application'
 require_relative 'datastore_api/responses/application_result'
 require_relative 'datastore_api/responses/healthcheck_result'
 
+require_relative '../engines/health_engine' if defined?(Rails)
+
 module DatastoreApi
 end

--- a/lib/datastore_api/version.rb
+++ b/lib/datastore_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatastoreApi
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/datastore_api/configuration_spec.rb
+++ b/spec/datastore_api/configuration_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe DatastoreApi::Configuration do
       let(:custom_value) { '/api/v2' }
 
       before do
-        DatastoreApi.configure { |config| config.api_root = custom_value }
+        DatastoreApi.configure { |config| config.api_path = custom_value }
       end
 
       it 'returns configured value' do
-        expect(config.api_root).to eq(custom_value)
+        expect(config.api_path).to eq(custom_value)
       end
     end
   end

--- a/spec/services/datastore_api/health_engine/get_request_spec.rb
+++ b/spec/services/datastore_api/health_engine/get_request_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative '../../../../engines/app/services/datastore_api/health_engine/get_request'
+
+RSpec.describe DatastoreApi::HealthEngine::GetRequest do
+  let(:api_root) { 'http://datastore-service-test' }
+
+  before do
+    allow(DatastoreApi.configuration).to receive(:api_root).and_return(api_root)
+  end
+
+  describe '.call' do
+    subject { described_class.call(:action) }
+
+    let(:endpoint) { "#{api_root}/action" }
+
+    context 'for a successful request' do
+      before do
+        allow(Faraday).to receive(:get).with(endpoint).and_return(response)
+      end
+
+      context 'with a successful response' do
+        let(:response) { double(success?: true, body: '{}') }
+
+        it 'has a response' do
+          expect(subject.response).to eq({})
+        end
+
+        it 'has a status' do
+          expect(subject.status).to eq(:ok)
+        end
+      end
+
+      context 'with a failure response' do
+        let(:response) { double(success?: false, body: '{}') }
+
+        it 'has a response' do
+          expect(subject.response).to eq({})
+        end
+
+        it 'has a status' do
+          expect(subject.status).to eq(:service_unavailable)
+        end
+      end
+    end
+
+    context 'for an unsuccessful request' do
+      before do
+        allow(Faraday).to receive(:get).with(endpoint).and_raise(StandardError.new('boom!'))
+      end
+
+      it 'has a response' do
+        expect(subject.response).to eq({ error: 'boom!' })
+      end
+
+      it 'has a status' do
+        expect(subject.status).to eq(:service_unavailable)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Basic initial approach to expose the /ping and /health endpoints from the datastore, through Apply and Review by way of using a rails engine that mounts these 2 routes in the host application.

This ultimately behaves similar to a proxy for those endpoints, as datastore does not have an ingress, access is internal to the cluster.

Note despite adding the rails gem to the `Gemfile`, this is only for gem development. At runtime there is no such requirement, so technically this gem is still rails-agnostic and the engine will only load in Rails apps (`if defined?(Rails)`)