### PR TITLE
CRIMAP-525 Support documents API endpoints

### DIFF
--- a/lib/datastore_api.rb
+++ b/lib/datastore_api.rb
@@ -12,6 +12,7 @@ require_relative 'datastore_api/decorators/paginated_collection'
 
 require_relative 'datastore_api/traits/api_request'
 require_relative 'datastore_api/traits/paginated_response'
+require_relative 'datastore_api/traits/s3_presigned_url'
 
 require_relative 'datastore_api/requests/healthcheck'
 require_relative 'datastore_api/requests/create_application'
@@ -21,6 +22,13 @@ require_relative 'datastore_api/requests/search_applications'
 require_relative 'datastore_api/requests/update_application'
 require_relative 'datastore_api/requests/delete_application'
 
+# require_relative 'datastore_api/requests/documents/list'
+# require_relative 'datastore_api/requests/documents/upload'
+# require_relative 'datastore_api/requests/documents/delete'
+require_relative 'datastore_api/requests/documents/presign_upload'
+require_relative 'datastore_api/requests/documents/presign_download'
+
+require_relative 'datastore_api/responses/document_result'
 require_relative 'datastore_api/responses/application_result'
 require_relative 'datastore_api/responses/healthcheck_result'
 

--- a/lib/datastore_api/requests/documents/presign_download.rb
+++ b/lib/datastore_api/requests/documents/presign_download.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Requests
+    module Documents
+      class PresignDownload
+        include Traits::ApiRequest
+        include Traits::S3PresignedUrl
+
+        attr_reader :object_key, :s3_opts
+
+        # Instantiate a presigned document download
+        #
+        # @param object_key [String] The object key to read
+        # @param s3_opts [Hash] Additional S3 options, like `expires_in`
+        #
+        # @raise [ArgumentError] if +object_key+ is missing or +nil+
+        #
+        # @return [DatastoreApi::Requests::Documents::PresignDownload] instance
+        #
+        def initialize(object_key:, **s3_opts)
+          raise ArgumentError, '`object_key` cannot be nil' unless object_key
+
+          @object_key = object_key
+          @s3_opts = s3_opts
+        end
+
+        def action
+          'presign_download'
+        end
+      end
+    end
+  end
+end

--- a/lib/datastore_api/requests/documents/presign_upload.rb
+++ b/lib/datastore_api/requests/documents/presign_upload.rb
@@ -11,11 +11,13 @@ module DatastoreApi
 
         # Instantiate a presigned document upload
         #
-        # @param usn [String] Application unique sequence number
+        # @param usn [Integer] Application unique sequence number
         # @param application_id [String] Application UUID
         # @param s3_opts [Hash] Additional S3 options, like `expires_in`
         #
-        # @raise [ArgumentError] if +object_key+ is missing or +nil+
+        # @raise [ArgumentError] if +usn+ is missing or +nil+
+        # @raise [ArgumentError] if +application_id+ is missing or +nil+
+        # @raise [ArgumentError] if +filename+ is missing or +nil+
         #
         # @return [DatastoreApi::Requests::Documents::PresignUpload] instance
         #

--- a/lib/datastore_api/requests/documents/presign_upload.rb
+++ b/lib/datastore_api/requests/documents/presign_upload.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Requests
+    module Documents
+      class PresignUpload
+        include Traits::ApiRequest
+        include Traits::S3PresignedUrl
+
+        attr_reader :usn, :application_id, :filename, :s3_opts
+
+        # Instantiate a presigned document upload
+        #
+        # @param usn [String] Application unique sequence number
+        # @param application_id [String] Application UUID
+        # @param s3_opts [Hash] Additional S3 options, like `expires_in`
+        #
+        # @raise [ArgumentError] if +object_key+ is missing or +nil+
+        #
+        # @return [DatastoreApi::Requests::Documents::PresignUpload] instance
+        #
+        def initialize(usn:, application_id:, filename:, **s3_opts)
+          raise ArgumentError, '`usn` cannot be nil' unless usn
+          raise ArgumentError, '`application_id` cannot be nil' unless application_id
+          raise ArgumentError, '`filename` cannot be nil' unless filename
+
+          @usn = usn
+          @application_id = application_id
+          @filename = filename
+          @s3_opts = s3_opts
+        end
+
+        def action
+          'presign_upload'
+        end
+
+        private
+
+        def object_key
+          [
+            usn,
+            application_id,
+            filename
+          ].join('/')
+        end
+      end
+    end
+  end
+end

--- a/lib/datastore_api/requests/documents/presign_upload.rb
+++ b/lib/datastore_api/requests/documents/presign_upload.rb
@@ -7,27 +7,23 @@ module DatastoreApi
         include Traits::ApiRequest
         include Traits::S3PresignedUrl
 
-        attr_reader :usn, :application_id, :filename, :s3_opts
+        attr_reader :usn, :filename, :s3_opts
 
         # Instantiate a presigned document upload
         #
         # @param usn [Integer] Application unique sequence number
-        # @param application_id [String] Application UUID
         # @param s3_opts [Hash] Additional S3 options, like `expires_in`
         #
         # @raise [ArgumentError] if +usn+ is missing or +nil+
-        # @raise [ArgumentError] if +application_id+ is missing or +nil+
         # @raise [ArgumentError] if +filename+ is missing or +nil+
         #
         # @return [DatastoreApi::Requests::Documents::PresignUpload] instance
         #
-        def initialize(usn:, application_id:, filename:, **s3_opts)
+        def initialize(usn:, filename:, **s3_opts)
           raise ArgumentError, '`usn` cannot be nil' unless usn
-          raise ArgumentError, '`application_id` cannot be nil' unless application_id
           raise ArgumentError, '`filename` cannot be nil' unless filename
 
           @usn = usn
-          @application_id = application_id
           @filename = filename
           @s3_opts = s3_opts
         end
@@ -39,11 +35,7 @@ module DatastoreApi
         private
 
         def object_key
-          [
-            usn,
-            application_id,
-            filename
-          ].join('/')
+          [usn, filename].join('/')
         end
       end
     end

--- a/lib/datastore_api/responses/document_result.rb
+++ b/lib/datastore_api/responses/document_result.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Responses
+    class DocumentResult < SimpleDelegator
+      # Just a few basic attributes for quick access
+      FIELDS = %w[
+        object_key
+        size
+        last_modified
+        url
+      ].freeze
+
+      attr_reader(*FIELDS)
+
+      # Instantiate a document result
+      #
+      # @param response [Hash] The API response for the operation
+      # @return [DatastoreApi::Responses::DocumentResult] instance
+      #
+      def initialize(response)
+        FIELDS.each do |field|
+          instance_variable_set(:"@#{field}", response[field])
+        end
+
+        super
+      end
+    end
+  end
+end

--- a/lib/datastore_api/traits/s3_presigned_url.rb
+++ b/lib/datastore_api/traits/s3_presigned_url.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Traits
+    module S3PresignedUrl
+      # Get a presigned URL
+      #
+      # @raise [DatastoreApi::Errors::ApiError] refer to lib/datastore_api/errors.rb
+      # @return [Responses::DocumentResult] result response
+      #
+      def call
+        Responses::DocumentResult.new(
+          http_client.put(endpoint, payload)
+        )
+      end
+
+      def endpoint
+        format('/documents/%<action>s', action:)
+      end
+
+      # :nocov:
+      def action
+        raise 'implement in classes that include this trait module'
+      end
+      # :nocov:
+
+      private
+
+      def payload
+        { object_key:, s3_opts: }
+      end
+    end
+  end
+end

--- a/spec/datastore_api/requests/documents/presign_download_spec.rb
+++ b/spec/datastore_api/requests/documents/presign_download_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Requests::Documents::PresignDownload do
+  subject { described_class.new(**args) }
+
+  let(:http_client) { instance_double(DatastoreApi::HttpClient, put: {}) }
+
+  let(:args) {
+    { object_key: '123/xyz/foobar', expires_in: 15 }
+  }
+
+  describe '#action' do
+    it { expect(subject.action).to eq('presign_download') }
+  end
+
+  describe '.new' do
+    let(:args) { { object_key: nil } }
+
+    it 'raises an error if the object_key is nil' do
+      expect {
+        subject.call
+      }.to raise_error(ArgumentError, '`object_key` cannot be nil')
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(subject).to receive(:http_client).and_return(http_client)
+    end
+
+    it_behaves_like 'an API request'
+
+    it 'wraps the response in an DocumentResult' do
+      expect(subject.call).to be_a(DatastoreApi::Responses::DocumentResult)
+    end
+
+    context 'endpoint' do
+      it 'uses the correct endpoint' do
+        expect(http_client).to receive(:put).with(
+          '/documents/presign_download', { object_key: '123/xyz/foobar', s3_opts: { expires_in: 15 } }
+        )
+
+        subject.call
+      end
+    end
+  end
+end

--- a/spec/datastore_api/requests/documents/presign_download_spec.rb
+++ b/spec/datastore_api/requests/documents/presign_download_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DatastoreApi::Requests::Documents::PresignDownload do
   let(:http_client) { instance_double(DatastoreApi::HttpClient, put: {}) }
 
   let(:args) {
-    { object_key: '123/xyz/foobar', expires_in: 15 }
+    { object_key: '123/payslip.pdf', expires_in: 15 }
   }
 
   describe '#action' do
@@ -37,7 +37,7 @@ RSpec.describe DatastoreApi::Requests::Documents::PresignDownload do
     context 'endpoint' do
       it 'uses the correct endpoint' do
         expect(http_client).to receive(:put).with(
-          '/documents/presign_download', { object_key: '123/xyz/foobar', s3_opts: { expires_in: 15 } }
+          '/documents/presign_download', { object_key: '123/payslip.pdf', s3_opts: { expires_in: 15 } }
         )
 
         subject.call

--- a/spec/datastore_api/requests/documents/presign_upload_spec.rb
+++ b/spec/datastore_api/requests/documents/presign_upload_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Requests::Documents::PresignUpload do
+  subject { described_class.new(**args) }
+
+  let(:http_client) { instance_double(DatastoreApi::HttpClient, put: {}) }
+
+  let(:args) {
+    { usn: 123, application_id: 'xyz', filename: 'payslip.pdf', expires_in: 15 }
+  }
+
+  describe '#action' do
+    it { expect(subject.action).to eq('presign_upload') }
+  end
+
+  describe '.new' do
+    context 'usn is not provided' do
+      let(:args) { super().merge(usn: nil) }
+
+      it 'raises an error if the usn is nil' do
+        expect {
+          subject.call
+        }.to raise_error(ArgumentError, '`usn` cannot be nil')
+      end
+    end
+
+    context 'application_id is not provided' do
+      let(:args) { super().merge(application_id: nil) }
+
+      it 'raises an error if the application_id is nil' do
+        expect {
+          subject.call
+        }.to raise_error(ArgumentError, '`application_id` cannot be nil')
+      end
+    end
+
+    context 'filename is not provided' do
+      let(:args) { super().merge(filename: nil) }
+
+      it 'raises an error if the filename is nil' do
+        expect {
+          subject.call
+        }.to raise_error(ArgumentError, '`filename` cannot be nil')
+      end
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(subject).to receive(:http_client).and_return(http_client)
+    end
+
+    it_behaves_like 'an API request'
+
+    it 'wraps the response in an DocumentResult' do
+      expect(subject.call).to be_a(DatastoreApi::Responses::DocumentResult)
+    end
+
+    context 'endpoint' do
+      it 'uses the correct endpoint' do
+        expect(http_client).to receive(:put).with(
+          '/documents/presign_upload', { object_key: '123/xyz/payslip.pdf', s3_opts: { expires_in: 15 } }
+        )
+
+        subject.call
+      end
+    end
+  end
+end

--- a/spec/datastore_api/requests/documents/presign_upload_spec.rb
+++ b/spec/datastore_api/requests/documents/presign_upload_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DatastoreApi::Requests::Documents::PresignUpload do
   let(:http_client) { instance_double(DatastoreApi::HttpClient, put: {}) }
 
   let(:args) {
-    { usn: 123, application_id: 'xyz', filename: 'payslip.pdf', expires_in: 15 }
+    { usn: 123, filename: 'payslip.pdf', expires_in: 15 }
   }
 
   describe '#action' do
@@ -21,16 +21,6 @@ RSpec.describe DatastoreApi::Requests::Documents::PresignUpload do
         expect {
           subject.call
         }.to raise_error(ArgumentError, '`usn` cannot be nil')
-      end
-    end
-
-    context 'application_id is not provided' do
-      let(:args) { super().merge(application_id: nil) }
-
-      it 'raises an error if the application_id is nil' do
-        expect {
-          subject.call
-        }.to raise_error(ArgumentError, '`application_id` cannot be nil')
       end
     end
 
@@ -59,7 +49,7 @@ RSpec.describe DatastoreApi::Requests::Documents::PresignUpload do
     context 'endpoint' do
       it 'uses the correct endpoint' do
         expect(http_client).to receive(:put).with(
-          '/documents/presign_upload', { object_key: '123/xyz/payslip.pdf', s3_opts: { expires_in: 15 } }
+          '/documents/presign_upload', { object_key: '123/payslip.pdf', s3_opts: { expires_in: 15 } }
         )
 
         subject.call


### PR DESCRIPTION
Initial support for new documents endpoints being implemented in the datastore.

There will be a `DatastoreApi::Requests::Documents::XYZ` request corresponding with each new datastore endpoint.

PR is split so it is not too large, some operations will be added in separate PRs.

I've shared on slack a document on how to test these PRs.