### PR TITLE
CRIMAP-525 Support list and delete file operations

### DIFF
--- a/lib/datastore_api.rb
+++ b/lib/datastore_api.rb
@@ -22,9 +22,9 @@ require_relative 'datastore_api/requests/search_applications'
 require_relative 'datastore_api/requests/update_application'
 require_relative 'datastore_api/requests/delete_application'
 
-# require_relative 'datastore_api/requests/documents/list'
+require_relative 'datastore_api/requests/documents/list'
+require_relative 'datastore_api/requests/documents/delete'
 # require_relative 'datastore_api/requests/documents/upload'
-# require_relative 'datastore_api/requests/documents/delete'
 require_relative 'datastore_api/requests/documents/presign_upload'
 require_relative 'datastore_api/requests/documents/presign_download'
 

--- a/lib/datastore_api/requests/documents/delete.rb
+++ b/lib/datastore_api/requests/documents/delete.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Requests
+    module Documents
+      class Delete
+        include Traits::ApiRequest
+
+        attr_reader :object_key
+
+        # Instantiate a document deletion
+        #
+        # @param object_key [String] The object key to delete
+        #
+        # @raise [ArgumentError] if +object_key+ is missing or +nil+
+        #
+        # @return [DatastoreApi::Requests::Documents::Delete] instance
+        #
+        def initialize(object_key:)
+          raise ArgumentError, '`object_key` cannot be nil' unless object_key
+
+          @object_key = object_key
+        end
+
+        # Delete a file
+        #
+        # @raise [DatastoreApi::Errors::ApiError] refer to lib/datastore_api/errors.rb
+        # @return [Responses::DocumentResult] result response
+        #
+        def call
+          Responses::DocumentResult.new(
+            http_client.delete(endpoint)
+          )
+        end
+
+        def endpoint
+          format(
+            '/documents/%<encoded_object_key>s', encoded_object_key:
+          )
+        end
+
+        private
+
+        def encoded_object_key
+          CGI.escape(
+            Base64.strict_encode64(object_key)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/datastore_api/requests/documents/list.rb
+++ b/lib/datastore_api/requests/documents/list.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module DatastoreApi
+  module Requests
+    module Documents
+      class List
+        include Traits::ApiRequest
+
+        attr_reader :usn
+
+        # Instantiate a documents listing
+        #
+        # @param usn [String] Application unique sequence number
+        #
+        # @raise [ArgumentError] if +usn+ is missing or +nil+
+        #
+        # @return [DatastoreApi::Requests::Documents::List] instance
+        #
+        def initialize(usn:)
+          raise ArgumentError, '`usn` cannot be nil' unless usn
+
+          @usn = usn
+        end
+
+        # Lists all files
+        #
+        # @raise [DatastoreApi::Errors::ApiError] refer to lib/datastore_api/errors.rb
+        # @return [Array[Responses::DocumentResult]] result response
+        #
+        def call
+          http_client.get(endpoint).map do |object|
+            Responses::DocumentResult.new(object)
+          end
+        end
+
+        def endpoint
+          format('/documents/%<usn>s', usn:)
+        end
+      end
+    end
+  end
+end

--- a/spec/datastore_api/requests/documents/delete_spec.rb
+++ b/spec/datastore_api/requests/documents/delete_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Requests::Documents::Delete do
+  subject { described_class.new(**args) }
+
+  let(:http_client) { instance_double(DatastoreApi::HttpClient, delete: {}) }
+
+  let(:args) {
+    { object_key: '123/file.docx' }
+  }
+
+  describe '.new' do
+    let(:args) { { object_key: nil } }
+
+    it 'raises an error if the object_key is nil' do
+      expect {
+        subject.call
+      }.to raise_error(ArgumentError, '`object_key` cannot be nil')
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(subject).to receive(:http_client).and_return(http_client)
+    end
+
+    it_behaves_like 'an API request'
+
+    it 'wraps the response in an DocumentResult' do
+      expect(subject.call).to be_a(DatastoreApi::Responses::DocumentResult)
+    end
+
+    context 'endpoint' do
+      it 'uses the correct endpoint' do
+        expect(http_client).to receive(:delete).with('/documents/MTIzL2ZpbGUuZG9jeA%3D%3D')
+        subject.call
+      end
+    end
+  end
+end

--- a/spec/datastore_api/requests/documents/list_spec.rb
+++ b/spec/datastore_api/requests/documents/list_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe DatastoreApi::Requests::Documents::List do
+  subject { described_class.new(**args) }
+
+  let(:http_client) { instance_double(DatastoreApi::HttpClient, get: [{}]) }
+
+  let(:args) {
+    { usn: 123 }
+  }
+
+  describe '.new' do
+    context 'usn is not provided' do
+      let(:args) { { usn: nil } }
+
+      it 'raises an error if the usn is nil' do
+        expect {
+          subject.call
+        }.to raise_error(ArgumentError, '`usn` cannot be nil')
+      end
+    end
+  end
+
+  describe '#call' do
+    before do
+      allow(subject).to receive(:http_client).and_return(http_client)
+    end
+
+    it_behaves_like 'an API request'
+
+    it 'wraps the response in an DocumentResult' do
+      expect(subject.call).to all(be_an(DatastoreApi::Responses::DocumentResult))
+    end
+
+    context 'endpoint' do
+      it 'uses the correct endpoint' do
+        expect(http_client).to receive(:get).with('/documents/123')
+        subject.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to previous PR #9.

List and Delete operations, corresponding to List and Delete datastore endpoints.

PR is split so it is not too large, some operations will be added in separate PRs.

I've shared on slack a document on how to test these PRs.