### PR TITLE
Presigned uploads generate random filename

### DIFF
--- a/lib/datastore_api/requests/documents/presign_upload.rb
+++ b/lib/datastore_api/requests/documents/presign_upload.rb
@@ -7,7 +7,7 @@ module DatastoreApi
         include Traits::ApiRequest
         include Traits::S3PresignedUrl
 
-        attr_reader :usn, :filename, :s3_opts
+        attr_reader :usn, :s3_opts
 
         # Instantiate a presigned document upload
         #
@@ -15,16 +15,13 @@ module DatastoreApi
         # @param s3_opts [Hash] Additional S3 options, like `expires_in`
         #
         # @raise [ArgumentError] if +usn+ is missing or +nil+
-        # @raise [ArgumentError] if +filename+ is missing or +nil+
         #
         # @return [DatastoreApi::Requests::Documents::PresignUpload] instance
         #
-        def initialize(usn:, filename:, **s3_opts)
+        def initialize(usn:, **s3_opts)
           raise ArgumentError, '`usn` cannot be nil' unless usn
-          raise ArgumentError, '`filename` cannot be nil' unless filename
 
           @usn = usn
-          @filename = filename
           @s3_opts = s3_opts
         end
 
@@ -32,10 +29,14 @@ module DatastoreApi
           'presign_upload'
         end
 
-        private
-
         def object_key
           [usn, filename].join('/')
+        end
+
+        private
+
+        def filename
+          @filename ||= SecureRandom.alphanumeric(10)
         end
       end
     end

--- a/lib/datastore_api/traits/s3_presigned_url.rb
+++ b/lib/datastore_api/traits/s3_presigned_url.rb
@@ -22,6 +22,10 @@ module DatastoreApi
       def action
         raise 'implement in classes that include this trait module'
       end
+
+      def object_key
+        raise 'implement in classes that include this trait module'
+      end
       # :nocov:
 
       private

--- a/spec/datastore_api/requests/documents/presign_download_spec.rb
+++ b/spec/datastore_api/requests/documents/presign_download_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe DatastoreApi::Requests::Documents::PresignDownload do
     it { expect(subject.action).to eq('presign_download') }
   end
 
+  describe '#object_key' do
+    it { expect(subject.object_key).to eq(args[:object_key]) }
+  end
+
   describe '.new' do
     let(:args) { { object_key: nil } }
 


### PR DESCRIPTION
We want the filenames to be randomly generated so files are not stored in S3 bucket with their original filenames which means we would have to sanitise some pesky characters and also we could inadvertently leak PII being part of the filenames.

As we are storing each file in its own USN prefix, collisions are almost nonexistent with just a few random chars. Also providers will not be uploading thousand of files per USN anyways.

No changes are required in the Datastore.